### PR TITLE
add ox xml dependency to make aws helper module self contained

### DIFF
--- a/kubes_aws.gemspec
+++ b/kubes_aws.gemspec
@@ -31,6 +31,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "aws_data"
   spec.add_dependency "memoist"
   spec.add_dependency "zeitwerk"
+  spec.add_dependency "ox"
 
   spec.add_development_dependency "kubes"
 end


### PR DESCRIPTION
add the xml dependency that the aws library wants to avoid library issues